### PR TITLE
Check if Ruby is installed

### DIFF
--- a/generate_templates.sh
+++ b/generate_templates.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+command -v ruby >/dev/null 2>&1 || { echo "ERROR: Please install Ruby." >&2; exit 1; }
+
 for template in $(find {debian,ubuntu} -name '*.yaml'); do
     if [ ! -f "${template}" ]; then continue; fi
     echo "Generating ${template/yaml/json}"


### PR DESCRIPTION
I didn't have Ruby installed and got lots of error messages:

$ ./generate_templates.sh
Generating debian/jessie/base-jessie32.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating debian/jessie/base-jessie64.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating debian/jessie/cinnamon-crypt-efi-jessie64.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating debian/jessie/cinnamon-crypt-jessie32.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating debian/jessie/cinnamon-crypt-jessie64.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating debian/jessie/cinnamon-jessie32.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating debian/jessie/cinnamon-jessie64.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating debian/stretch/base-stretch32.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating debian/stretch/base-stretch64.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating debian/stretch/cinnamon-crypt-efi-stretch64.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating debian/stretch/cinnamon-crypt-stretch32.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating debian/stretch/cinnamon-crypt-stretch64.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating debian/stretch/cinnamon-stretch32.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating debian/stretch/cinnamon-stretch64.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating debian/wheezy/base-wheezy32.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating debian/wheezy/base-wheezy64.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating debian/wheezy/xfce-crypt-wheezy32.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating debian/wheezy/xfce-crypt-wheezy64.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating ubuntu/precise/base-precise32.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating ubuntu/precise/base-precise64.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating ubuntu/trusty/base-trusty32.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating ubuntu/trusty/base-trusty64.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating ubuntu/wily/base-wily32.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating ubuntu/wily/base-wily64.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating ubuntu/xenial/base-xenial32.json
/usr/bin/env: ‘ruby’: No such file or directory
Generating ubuntu/xenial/base-xenial64.json
/usr/bin/env: ‘ruby’: No such file or directory
