### PR TITLE
Use text mode boot interface for entering boot command

### DIFF
--- a/source/ubuntu/18.04_bionic/base.yaml
+++ b/source/ubuntu/18.04_bionic/base.yaml
@@ -8,7 +8,7 @@ _ANCHORS:
 - &builder_common_options
   boot_command:
   - '<esc><esc><enter><wait>'
-  - 'initrd=/install/initrd.gz '
+  - 'install initrd=/install/initrd.gz '
   - 'auto=true '
   - 'url=http://{{.HTTPIP}}:{{.HTTPPort}}/{{user `preseed_file`}} '
   - 'language={{user `language`}} '

--- a/source/ubuntu/18.04_bionic/base.yaml
+++ b/source/ubuntu/18.04_bionic/base.yaml
@@ -7,16 +7,7 @@
 _ANCHORS:
 - &builder_common_options
   boot_command:
-  - '<esc><f6><esc>'
-  - '<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>'
-  - '<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>'
-  - '<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>'
-  - '<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>'
-  - '<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>'
-  - '<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>'
-  - '<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>'
-  - '<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>'
-  - '<bs><bs><bs>'
+  - '<esc><esc><enter><wait>'
   - 'initrd=/install/initrd.gz '
   - 'auto=true '
   - 'url=http://{{.HTTPIP}}:{{.HTTPPort}}/{{user `preseed_file`}} '


### PR DESCRIPTION
A [bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=823459) in syslinux prevented from input being recognized on the text mode boot interface, which was fixed in [syslinux_6.03+dfsg-14](http://changelogs.ubuntu.com/changelogs/pool/main/s/syslinux/syslinux_6.03+dfsg-14/changelog):
>     + 0012: fix input on the boot prompt are ignored.  Closes: #823459

So now we can do what we did to enter the boot options in 12.04 and earlier, by doing `<esc><esc><enter><wait>` to got to the boot option prompt (instead of all of the `<bs>`s to manipulate the graphical mode boot interface). 

This probably works for the 18.10 version too, but given how long its taking the images to download for me, I'm just going to do 18.04. 