### PR TITLE
Set VM clock according to OS settings

### DIFF
--- a/source/debian/10_buster/base-crypt-uefi.yaml
+++ b/source/debian/10_buster/base-crypt-uefi.yaml
@@ -115,6 +115,15 @@ builders:
     - '{{.Name}}'
     - '--firmware'
     - efi
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/10_buster/base-crypt.yaml
+++ b/source/debian/10_buster/base-crypt.yaml
@@ -110,6 +110,15 @@ builders:
     - '{{.Name}}'
     - '--cpus'
     - '{{user `cpus`}}'
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/10_buster/base-uefi.yaml
+++ b/source/debian/10_buster/base-uefi.yaml
@@ -115,6 +115,15 @@ builders:
     - '{{.Name}}'
     - '--firmware'
     - efi
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/10_buster/base.yaml
+++ b/source/debian/10_buster/base.yaml
@@ -110,6 +110,15 @@ builders:
     - '{{.Name}}'
     - '--cpus'
     - '{{user `cpus`}}'
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/10_buster/cinnamon-crypt-uefi.yaml
+++ b/source/debian/10_buster/cinnamon-crypt-uefi.yaml
@@ -115,6 +115,15 @@ builders:
     - '{{.Name}}'
     - '--firmware'
     - efi
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/10_buster/cinnamon-crypt.yaml
+++ b/source/debian/10_buster/cinnamon-crypt.yaml
@@ -110,6 +110,15 @@ builders:
     - '{{.Name}}'
     - '--cpus'
     - '{{user `cpus`}}'
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/10_buster/cinnamon-uefi.yaml
+++ b/source/debian/10_buster/cinnamon-uefi.yaml
@@ -115,6 +115,15 @@ builders:
     - '{{.Name}}'
     - '--firmware'
     - efi
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/10_buster/cinnamon.yaml
+++ b/source/debian/10_buster/cinnamon.yaml
@@ -110,6 +110,15 @@ builders:
     - '{{.Name}}'
     - '--cpus'
     - '{{user `cpus`}}'
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/8_jessie/base-crypt-uefi.yaml
+++ b/source/debian/8_jessie/base-crypt-uefi.yaml
@@ -115,6 +115,15 @@ builders:
     - '{{.Name}}'
     - '--firmware'
     - efi
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/8_jessie/base-crypt.yaml
+++ b/source/debian/8_jessie/base-crypt.yaml
@@ -110,6 +110,15 @@ builders:
     - '{{.Name}}'
     - '--cpus'
     - '{{user `cpus`}}'
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/8_jessie/base-uefi.yaml
+++ b/source/debian/8_jessie/base-uefi.yaml
@@ -115,6 +115,15 @@ builders:
     - '{{.Name}}'
     - '--firmware'
     - efi
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/8_jessie/base.yaml
+++ b/source/debian/8_jessie/base.yaml
@@ -110,6 +110,15 @@ builders:
     - '{{.Name}}'
     - '--cpus'
     - '{{user `cpus`}}'
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/8_jessie/cinnamon-crypt-uefi.yaml
+++ b/source/debian/8_jessie/cinnamon-crypt-uefi.yaml
@@ -115,6 +115,15 @@ builders:
     - '{{.Name}}'
     - '--firmware'
     - efi
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/8_jessie/cinnamon-crypt.yaml
+++ b/source/debian/8_jessie/cinnamon-crypt.yaml
@@ -110,6 +110,15 @@ builders:
     - '{{.Name}}'
     - '--cpus'
     - '{{user `cpus`}}'
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/8_jessie/cinnamon-uefi.yaml
+++ b/source/debian/8_jessie/cinnamon-uefi.yaml
@@ -115,6 +115,15 @@ builders:
     - '{{.Name}}'
     - '--firmware'
     - efi
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/8_jessie/cinnamon.yaml
+++ b/source/debian/8_jessie/cinnamon.yaml
@@ -110,6 +110,15 @@ builders:
     - '{{.Name}}'
     - '--cpus'
     - '{{user `cpus`}}'
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/9_stretch/base-crypt-uefi.yaml
+++ b/source/debian/9_stretch/base-crypt-uefi.yaml
@@ -115,6 +115,15 @@ builders:
     - '{{.Name}}'
     - '--firmware'
     - efi
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/9_stretch/base-crypt.yaml
+++ b/source/debian/9_stretch/base-crypt.yaml
@@ -110,6 +110,15 @@ builders:
     - '{{.Name}}'
     - '--cpus'
     - '{{user `cpus`}}'
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/9_stretch/base-uefi.yaml
+++ b/source/debian/9_stretch/base-uefi.yaml
@@ -115,6 +115,15 @@ builders:
     - '{{.Name}}'
     - '--firmware'
     - efi
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/9_stretch/base.yaml
+++ b/source/debian/9_stretch/base.yaml
@@ -110,6 +110,15 @@ builders:
     - '{{.Name}}'
     - '--cpus'
     - '{{user `cpus`}}'
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/9_stretch/cinnamon-crypt-uefi.yaml
+++ b/source/debian/9_stretch/cinnamon-crypt-uefi.yaml
@@ -115,6 +115,15 @@ builders:
     - '{{.Name}}'
     - '--firmware'
     - efi
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/9_stretch/cinnamon-crypt.yaml
+++ b/source/debian/9_stretch/cinnamon-crypt.yaml
@@ -110,6 +110,15 @@ builders:
     - '{{.Name}}'
     - '--cpus'
     - '{{user `cpus`}}'
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/9_stretch/cinnamon-uefi.yaml
+++ b/source/debian/9_stretch/cinnamon-uefi.yaml
@@ -115,6 +115,15 @@ builders:
     - '{{.Name}}'
     - '--firmware'
     - efi
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/debian/9_stretch/cinnamon.yaml
+++ b/source/debian/9_stretch/cinnamon.yaml
@@ -110,6 +110,15 @@ builders:
     - '{{.Name}}'
     - '--cpus'
     - '{{user `cpus`}}'
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/ubuntu/14.04_trusty/base-uefi.yaml
+++ b/source/ubuntu/14.04_trusty/base-uefi.yaml
@@ -120,6 +120,15 @@ builders:
     - '{{.Name}}'
     - '--firmware'
     - efi
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/ubuntu/14.04_trusty/base.yaml
+++ b/source/ubuntu/14.04_trusty/base.yaml
@@ -115,6 +115,15 @@ builders:
     - '{{.Name}}'
     - '--cpus'
     - '{{user `cpus`}}'
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/ubuntu/16.04_xenial/base-uefi.yaml
+++ b/source/ubuntu/16.04_xenial/base-uefi.yaml
@@ -120,6 +120,15 @@ builders:
     - '{{.Name}}'
     - '--firmware'
     - efi
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/ubuntu/16.04_xenial/base.yaml
+++ b/source/ubuntu/16.04_xenial/base.yaml
@@ -123,6 +123,15 @@ builders:
     - '{{.Name}}'
     - '--cpus'
     - '{{user `cpus`}}'
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/ubuntu/18.04_bionic/base-uefi.yaml
+++ b/source/ubuntu/18.04_bionic/base-uefi.yaml
@@ -120,6 +120,15 @@ builders:
     - '{{.Name}}'
     - '--firmware'
     - efi
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/ubuntu/18.04_bionic/base.yaml
+++ b/source/ubuntu/18.04_bionic/base.yaml
@@ -114,6 +114,15 @@ builders:
     - '{{.Name}}'
     - '--cpus'
     - '{{user `cpus`}}'
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/ubuntu/18.10_cosmic/base-uefi.yaml
+++ b/source/ubuntu/18.10_cosmic/base-uefi.yaml
@@ -120,6 +120,15 @@ builders:
     - '{{.Name}}'
     - '--firmware'
     - efi
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/ubuntu/18.10_cosmic/base.yaml
+++ b/source/ubuntu/18.10_cosmic/base.yaml
@@ -123,6 +123,15 @@ builders:
     - '{{.Name}}'
     - '--cpus'
     - '{{user `cpus`}}'
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/ubuntu/19.04_disco/base-uefi.yaml
+++ b/source/ubuntu/19.04_disco/base-uefi.yaml
@@ -120,6 +120,15 @@ builders:
     - '{{.Name}}'
     - '--firmware'
     - efi
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'

--- a/source/ubuntu/19.04_disco/base.yaml
+++ b/source/ubuntu/19.04_disco/base.yaml
@@ -123,6 +123,15 @@ builders:
     - '{{.Name}}'
     - '--cpus'
     - '{{user `cpus`}}'
+  - - modifyvm
+    - '{{.Name}}'
+    - '--rtcuseutc'
+    - >-
+      {{if user `system_clock_in_utc` | eq `true` -}}
+      on
+      {{- else -}}
+      off
+      {{- end}}
 # vboxmanage_post: (array of array of strings)
   virtualbox_version_file: '/tmp/.vbox_version'
   vrdp_bind_address: '{{user `vnc_vrdp_bind_address`}}'


### PR DESCRIPTION
Hi!

Currently vbox VM clock are being set to local time by default, although it specified that RTC is set to UTC in preseed files. I got in trouble running a custom firstboot script at the early boot stage, when system clock is not yet synchronized over NTP (generated SSL certificates remained invalid for several hours after synchronization). This change set a VM RTC according to the value of `system_clock_in_utc` variable.