### PR TITLE
Use correct name for preseed file

### DIFF
--- a/source/debian/10_buster/base-crypt-uefi.pkr.hcl
+++ b/source/debian/10_buster/base-crypt-uefi.pkr.hcl
@@ -308,7 +308,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -374,7 +374,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/10_buster/base-crypt.pkr.hcl
+++ b/source/debian/10_buster/base-crypt.pkr.hcl
@@ -307,7 +307,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -371,7 +371,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/10_buster/base-uefi.pkr.hcl
+++ b/source/debian/10_buster/base-uefi.pkr.hcl
@@ -308,7 +308,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -374,7 +374,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/10_buster/base.pkr.hcl
+++ b/source/debian/10_buster/base.pkr.hcl
@@ -307,7 +307,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -371,7 +371,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/10_buster/cinnamon-crypt-uefi.pkr.hcl
+++ b/source/debian/10_buster/cinnamon-crypt-uefi.pkr.hcl
@@ -308,7 +308,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -374,7 +374,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/10_buster/cinnamon-crypt.pkr.hcl
+++ b/source/debian/10_buster/cinnamon-crypt.pkr.hcl
@@ -307,7 +307,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -371,7 +371,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/10_buster/cinnamon-uefi.pkr.hcl
+++ b/source/debian/10_buster/cinnamon-uefi.pkr.hcl
@@ -308,7 +308,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -374,7 +374,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/10_buster/cinnamon.pkr.hcl
+++ b/source/debian/10_buster/cinnamon.pkr.hcl
@@ -307,7 +307,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -371,7 +371,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/11_bullseye/base-crypt-uefi.pkr.hcl
+++ b/source/debian/11_bullseye/base-crypt-uefi.pkr.hcl
@@ -308,7 +308,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -374,7 +374,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/11_bullseye/base-crypt.pkr.hcl
+++ b/source/debian/11_bullseye/base-crypt.pkr.hcl
@@ -307,7 +307,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -371,7 +371,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/11_bullseye/base-uefi.pkr.hcl
+++ b/source/debian/11_bullseye/base-uefi.pkr.hcl
@@ -308,7 +308,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -374,7 +374,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/11_bullseye/base.pkr.hcl
+++ b/source/debian/11_bullseye/base.pkr.hcl
@@ -307,7 +307,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -371,7 +371,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/11_bullseye/cinnamon-crypt-uefi.pkr.hcl
+++ b/source/debian/11_bullseye/cinnamon-crypt-uefi.pkr.hcl
@@ -308,7 +308,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -374,7 +374,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/11_bullseye/cinnamon-crypt.pkr.hcl
+++ b/source/debian/11_bullseye/cinnamon-crypt.pkr.hcl
@@ -307,7 +307,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -371,7 +371,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/11_bullseye/cinnamon-uefi.pkr.hcl
+++ b/source/debian/11_bullseye/cinnamon-uefi.pkr.hcl
@@ -308,7 +308,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -374,7 +374,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/11_bullseye/cinnamon.pkr.hcl
+++ b/source/debian/11_bullseye/cinnamon.pkr.hcl
@@ -307,7 +307,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -371,7 +371,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/12_bookworm/base-crypt-uefi.pkr.hcl
+++ b/source/debian/12_bookworm/base-crypt-uefi.pkr.hcl
@@ -308,7 +308,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -374,7 +374,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/12_bookworm/base-crypt.pkr.hcl
+++ b/source/debian/12_bookworm/base-crypt.pkr.hcl
@@ -307,7 +307,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -371,7 +371,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/12_bookworm/base-uefi.pkr.hcl
+++ b/source/debian/12_bookworm/base-uefi.pkr.hcl
@@ -308,7 +308,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -374,7 +374,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/12_bookworm/base.pkr.hcl
+++ b/source/debian/12_bookworm/base.pkr.hcl
@@ -307,7 +307,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -371,7 +371,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/12_bookworm/cinnamon-crypt-uefi.pkr.hcl
+++ b/source/debian/12_bookworm/cinnamon-crypt-uefi.pkr.hcl
@@ -308,7 +308,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -374,7 +374,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/12_bookworm/cinnamon-crypt.pkr.hcl
+++ b/source/debian/12_bookworm/cinnamon-crypt.pkr.hcl
@@ -307,7 +307,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -371,7 +371,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/12_bookworm/cinnamon-uefi.pkr.hcl
+++ b/source/debian/12_bookworm/cinnamon-uefi.pkr.hcl
@@ -308,7 +308,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -374,7 +374,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/debian/12_bookworm/cinnamon.pkr.hcl
+++ b/source/debian/12_bookworm/cinnamon.pkr.hcl
@@ -307,7 +307,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -371,7 +371,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/ubuntu/18.04_bionic/base-uefi.pkr.hcl
+++ b/source/ubuntu/18.04_bionic/base-uefi.pkr.hcl
@@ -308,7 +308,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -378,7 +378,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum

--- a/source/ubuntu/18.04_bionic/base.pkr.hcl
+++ b/source/ubuntu/18.04_bionic/base.pkr.hcl
@@ -306,7 +306,7 @@ source "qemu" "qemu" {
   headless             = var.headless
   host_port_max        = var.host_port_max
   host_port_min        = var.host_port_min
-  http_content         = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content         = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max        = var.http_port_max
   http_port_min        = var.http_port_min
   iso_checksum         = var.iso_checksum
@@ -374,7 +374,7 @@ source "virtualbox-iso" "vbox" {
   headless                 = var.headless
   host_port_max            = var.host_port_max
   host_port_min            = var.host_port_min
-  http_content             = { "/preseed.cfg" = templatefile(var.preseed_file, { var = var }) }
+  http_content             = { "/${var.preseed_file}" = templatefile(var.preseed_file, { var = var }) }
   http_port_max            = var.http_port_max
   http_port_min            = var.http_port_min
   iso_checksum             = var.iso_checksum


### PR DESCRIPTION
Packer is serving `/preseed.cfg` but we tell the system to look for `base*.preseed`
This PR fix that by using the var `preseed_file` as the name of the served file.