### PR TITLE
Fallback to downloading the iso to /tmp if PACKER_CACHE_DIR is not set

### DIFF
--- a/source/debian/10_buster/base-crypt-uefi.pkr.hcl
+++ b/source/debian/10_buster/base-crypt-uefi.pkr.hcl
@@ -314,7 +314,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -380,7 +380,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/10_buster/base-crypt.pkr.hcl
+++ b/source/debian/10_buster/base-crypt.pkr.hcl
@@ -313,7 +313,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -377,7 +377,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/10_buster/base-uefi.pkr.hcl
+++ b/source/debian/10_buster/base-uefi.pkr.hcl
@@ -314,7 +314,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -380,7 +380,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/10_buster/base.pkr.hcl
+++ b/source/debian/10_buster/base.pkr.hcl
@@ -313,7 +313,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -377,7 +377,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/10_buster/cinnamon-crypt-uefi.pkr.hcl
+++ b/source/debian/10_buster/cinnamon-crypt-uefi.pkr.hcl
@@ -314,7 +314,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -380,7 +380,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/10_buster/cinnamon-crypt.pkr.hcl
+++ b/source/debian/10_buster/cinnamon-crypt.pkr.hcl
@@ -313,7 +313,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -377,7 +377,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/10_buster/cinnamon-uefi.pkr.hcl
+++ b/source/debian/10_buster/cinnamon-uefi.pkr.hcl
@@ -314,7 +314,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -380,7 +380,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/10_buster/cinnamon.pkr.hcl
+++ b/source/debian/10_buster/cinnamon.pkr.hcl
@@ -313,7 +313,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -377,7 +377,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/11_bullseye/base-crypt-uefi.pkr.hcl
+++ b/source/debian/11_bullseye/base-crypt-uefi.pkr.hcl
@@ -314,7 +314,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -380,7 +380,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/11_bullseye/base-crypt.pkr.hcl
+++ b/source/debian/11_bullseye/base-crypt.pkr.hcl
@@ -313,7 +313,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -377,7 +377,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/11_bullseye/base-uefi.pkr.hcl
+++ b/source/debian/11_bullseye/base-uefi.pkr.hcl
@@ -314,7 +314,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -380,7 +380,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/11_bullseye/base.pkr.hcl
+++ b/source/debian/11_bullseye/base.pkr.hcl
@@ -313,7 +313,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -377,7 +377,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/11_bullseye/cinnamon-crypt-uefi.pkr.hcl
+++ b/source/debian/11_bullseye/cinnamon-crypt-uefi.pkr.hcl
@@ -314,7 +314,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -380,7 +380,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/11_bullseye/cinnamon-crypt.pkr.hcl
+++ b/source/debian/11_bullseye/cinnamon-crypt.pkr.hcl
@@ -313,7 +313,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -377,7 +377,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/11_bullseye/cinnamon-uefi.pkr.hcl
+++ b/source/debian/11_bullseye/cinnamon-uefi.pkr.hcl
@@ -314,7 +314,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -380,7 +380,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/11_bullseye/cinnamon.pkr.hcl
+++ b/source/debian/11_bullseye/cinnamon.pkr.hcl
@@ -313,7 +313,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -377,7 +377,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/12_bookworm/base-crypt-uefi.pkr.hcl
+++ b/source/debian/12_bookworm/base-crypt-uefi.pkr.hcl
@@ -314,7 +314,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -380,7 +380,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/12_bookworm/base-crypt.pkr.hcl
+++ b/source/debian/12_bookworm/base-crypt.pkr.hcl
@@ -313,7 +313,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -377,7 +377,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/12_bookworm/base-uefi.pkr.hcl
+++ b/source/debian/12_bookworm/base-uefi.pkr.hcl
@@ -314,7 +314,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -380,7 +380,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/12_bookworm/base.pkr.hcl
+++ b/source/debian/12_bookworm/base.pkr.hcl
@@ -313,7 +313,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -377,7 +377,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/12_bookworm/cinnamon-crypt-uefi.pkr.hcl
+++ b/source/debian/12_bookworm/cinnamon-crypt-uefi.pkr.hcl
@@ -314,7 +314,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -380,7 +380,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/12_bookworm/cinnamon-crypt.pkr.hcl
+++ b/source/debian/12_bookworm/cinnamon-crypt.pkr.hcl
@@ -313,7 +313,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -377,7 +377,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/12_bookworm/cinnamon-uefi.pkr.hcl
+++ b/source/debian/12_bookworm/cinnamon-uefi.pkr.hcl
@@ -314,7 +314,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -380,7 +380,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/debian/12_bookworm/cinnamon.pkr.hcl
+++ b/source/debian/12_bookworm/cinnamon.pkr.hcl
@@ -313,7 +313,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -377,7 +377,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/ubuntu/18.04_bionic/base-uefi.pkr.hcl
+++ b/source/ubuntu/18.04_bionic/base-uefi.pkr.hcl
@@ -314,7 +314,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -384,7 +384,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/ubuntu/18.04_bionic/base.pkr.hcl
+++ b/source/ubuntu/18.04_bionic/base.pkr.hcl
@@ -312,7 +312,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -380,7 +380,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/ubuntu/20.04_focal/base-uefi.pkr.hcl
+++ b/source/ubuntu/20.04_focal/base-uefi.pkr.hcl
@@ -308,7 +308,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -370,7 +370,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/ubuntu/20.04_focal/base.pkr.hcl
+++ b/source/ubuntu/20.04_focal/base.pkr.hcl
@@ -308,7 +308,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -367,7 +367,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/ubuntu/22.04_jammy/base-uefi.pkr.hcl
+++ b/source/ubuntu/22.04_jammy/base-uefi.pkr.hcl
@@ -308,7 +308,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -370,7 +370,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/ubuntu/22.04_jammy/base.pkr.hcl
+++ b/source/ubuntu/22.04_jammy/base.pkr.hcl
@@ -308,7 +308,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -367,7 +367,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/ubuntu/22.10_kinetic/base-uefi.pkr.hcl
+++ b/source/ubuntu/22.10_kinetic/base-uefi.pkr.hcl
@@ -308,7 +308,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -370,7 +370,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"

--- a/source/ubuntu/22.10_kinetic/base.pkr.hcl
+++ b/source/ubuntu/22.10_kinetic/base.pkr.hcl
@@ -308,7 +308,7 @@ source "qemu" "qemu" {
   iso_checksum         = var.iso_checksum
   iso_skip_cache       = false
   iso_target_extension = "iso"
-  iso_target_path      = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path      = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"
@@ -367,7 +367,7 @@ source "virtualbox-iso" "vbox" {
   iso_checksum             = var.iso_checksum
   iso_interface            = "sata"
   iso_target_extension     = "iso"
-  iso_target_path          = "${var.packer_cache_dir}/${var.iso_file}"
+  iso_target_path          = "${regex_replace(var.packer_cache_dir, "^$", "/tmp")}/${var.iso_file}"
   iso_urls = [
     "${var.iso_path_internal}/${var.iso_file}",
     "${var.iso_path_external}/${var.iso_file}"


### PR DESCRIPTION
If the environment variable `PACKER_CACHE_DIR` is not set the value of `iso_target_path` will be `/something.iso` and because we are not allowed to write at the root of the filesystem build will fail.
With this PR if `packer_cache_dir` is empty, which is what happen if `PACKER_CACHE_DIR` is not set, it will replace it with `/tmp`