### PR TITLE
Fix the templates path

### DIFF
--- a/source/debian/10_buster/base-crypt-uefi.pkr.hcl
+++ b/source/debian/10_buster/base-crypt-uefi.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/10_buster/base-crypt-uefi.preseed"
+  default = "base-crypt-uefi.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/10_buster/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -470,7 +470,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/10_buster/base-crypt.pkr.hcl
+++ b/source/debian/10_buster/base-crypt.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/10_buster/base-crypt.preseed"
+  default = "base-crypt.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/10_buster/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -455,7 +455,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/10_buster/base-uefi.pkr.hcl
+++ b/source/debian/10_buster/base-uefi.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/10_buster/base-uefi.preseed"
+  default = "base-uefi.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/10_buster/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -470,7 +470,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/10_buster/base.pkr.hcl
+++ b/source/debian/10_buster/base.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/10_buster/base.preseed"
+  default = "base.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/10_buster/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -455,7 +455,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/10_buster/cinnamon-crypt-uefi.pkr.hcl
+++ b/source/debian/10_buster/cinnamon-crypt-uefi.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/10_buster/cinnamon-crypt-uefi.preseed"
+  default = "cinnamon-crypt-uefi.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/10_buster/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -470,7 +470,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/10_buster/cinnamon-crypt.pkr.hcl
+++ b/source/debian/10_buster/cinnamon-crypt.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/10_buster/cinnamon-crypt.preseed"
+  default = "cinnamon-crypt.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/10_buster/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -455,7 +455,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/10_buster/cinnamon-uefi.pkr.hcl
+++ b/source/debian/10_buster/cinnamon-uefi.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/10_buster/cinnamon-uefi.preseed"
+  default = "cinnamon-uefi.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/10_buster/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -470,7 +470,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/10_buster/cinnamon.pkr.hcl
+++ b/source/debian/10_buster/cinnamon.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/10_buster/cinnamon.preseed"
+  default = "cinnamon.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/10_buster/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -455,7 +455,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/11_bullseye/base-crypt-uefi.pkr.hcl
+++ b/source/debian/11_bullseye/base-crypt-uefi.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/11_bullseye/base-crypt-uefi.preseed"
+  default = "base-crypt-uefi.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/11_bullseye/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -470,7 +470,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/11_bullseye/base-crypt.pkr.hcl
+++ b/source/debian/11_bullseye/base-crypt.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/11_bullseye/base-crypt.preseed"
+  default = "base-crypt.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/11_bullseye/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -455,7 +455,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/11_bullseye/base-uefi.pkr.hcl
+++ b/source/debian/11_bullseye/base-uefi.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/11_bullseye/base-uefi.preseed"
+  default = "base-uefi.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/11_bullseye/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -470,7 +470,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/11_bullseye/base.pkr.hcl
+++ b/source/debian/11_bullseye/base.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/11_bullseye/base.preseed"
+  default = "base.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/11_bullseye/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -415,7 +415,8 @@ source "virtualbox-iso" "vbox" {
 build {
   description = "Can't use variables here yet!"
 
-  sources = ["source.qemu.qemu", "source.virtualbox-iso.vbox"]
+#  sources = ["source.qemu.qemu", "source.virtualbox-iso.vbox"]
+  sources = ["source.qemu.qemu"]
 
   provisioner "shell" {
     binary              = false
@@ -455,7 +456,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/11_bullseye/cinnamon-crypt-uefi.pkr.hcl
+++ b/source/debian/11_bullseye/cinnamon-crypt-uefi.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/11_bullseye/cinnamon-crypt-uefi.preseed"
+  default = "cinnamon-crypt-uefi.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/11_bullseye/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -470,7 +470,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/11_bullseye/cinnamon-crypt.pkr.hcl
+++ b/source/debian/11_bullseye/cinnamon-crypt.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/11_bullseye/cinnamon-crypt.preseed"
+  default = "cinnamon-crypt.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/11_bullseye/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -455,7 +455,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/11_bullseye/cinnamon-uefi.pkr.hcl
+++ b/source/debian/11_bullseye/cinnamon-uefi.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/11_bullseye/cinnamon-uefi.preseed"
+  default = "cinnamon-uefi.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/11_bullseye/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -470,7 +470,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/11_bullseye/cinnamon.pkr.hcl
+++ b/source/debian/11_bullseye/cinnamon.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/11_bullseye/cinnamon.preseed"
+  default = "cinnamon.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/11_bullseye/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -455,7 +455,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/12_bookworm/base-crypt-uefi.pkr.hcl
+++ b/source/debian/12_bookworm/base-crypt-uefi.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/12_bookworm/base-crypt-uefi.preseed"
+  default = "base-crypt-uefi.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/12_bookworm/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -470,7 +470,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/12_bookworm/base-crypt.pkr.hcl
+++ b/source/debian/12_bookworm/base-crypt.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/12_bookworm/base-crypt.preseed"
+  default = "base-crypt.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/12_bookworm/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -455,7 +455,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/12_bookworm/base-uefi.pkr.hcl
+++ b/source/debian/12_bookworm/base-uefi.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/12_bookworm/base-uefi.preseed"
+  default = "base-uefi.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/12_bookworm/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -470,7 +470,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/12_bookworm/base.pkr.hcl
+++ b/source/debian/12_bookworm/base.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/12_bookworm/base.preseed"
+  default = "base.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/12_bookworm/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -455,7 +455,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/12_bookworm/cinnamon-crypt-uefi.pkr.hcl
+++ b/source/debian/12_bookworm/cinnamon-crypt-uefi.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/12_bookworm/cinnamon-crypt-uefi.preseed"
+  default = "cinnamon-crypt-uefi.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/12_bookworm/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -470,7 +470,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/12_bookworm/cinnamon-crypt.pkr.hcl
+++ b/source/debian/12_bookworm/cinnamon-crypt.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/12_bookworm/cinnamon-crypt.preseed"
+  default = "cinnamon-crypt.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/12_bookworm/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -455,7 +455,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/12_bookworm/cinnamon-uefi.pkr.hcl
+++ b/source/debian/12_bookworm/cinnamon-uefi.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/12_bookworm/cinnamon-uefi.preseed"
+  default = "cinnamon-uefi.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/12_bookworm/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -470,7 +470,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/debian/12_bookworm/cinnamon.pkr.hcl
+++ b/source/debian/12_bookworm/cinnamon.pkr.hcl
@@ -151,7 +151,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/debian/12_bookworm/cinnamon.preseed"
+  default = "cinnamon.preseed"
 }
 
 variable "qemu_binary" {
@@ -246,7 +246,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/debian/12_bookworm/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -455,7 +455,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/ubuntu/18.04_bionic/base-uefi.pkr.hcl
+++ b/source/ubuntu/18.04_bionic/base-uefi.pkr.hcl
@@ -146,7 +146,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/ubuntu/18.04_bionic/base-uefi.preseed"
+  default = "base-uefi.preseed"
 }
 
 variable "qemu_binary" {
@@ -241,7 +241,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/ubuntu/18.04_bionic/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -487,7 +487,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/ubuntu/18.04_bionic/base.pkr.hcl
+++ b/source/ubuntu/18.04_bionic/base.pkr.hcl
@@ -146,7 +146,7 @@ variable "packer_cache_dir" {
 
 variable "preseed_file" {
   type    = string
-  default = "template/ubuntu/18.04_bionic/base.preseed"
+  default = "base.preseed"
 }
 
 variable "qemu_binary" {
@@ -241,7 +241,7 @@ variable "timezone" {
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/ubuntu/18.04_bionic/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -468,7 +468,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/ubuntu/20.04_focal/base-uefi.pkr.hcl
+++ b/source/ubuntu/20.04_focal/base-uefi.pkr.hcl
@@ -241,12 +241,12 @@ variable "timezone" {
 
 variable "user_data_location" {
   type    = string
-  default = "template/ubuntu/20.04_focal/user-data"
+  default = "user-data"
 }
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/ubuntu/20.04_focal/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -459,7 +459,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/ubuntu/20.04_focal/base.pkr.hcl
+++ b/source/ubuntu/20.04_focal/base.pkr.hcl
@@ -241,12 +241,12 @@ variable "timezone" {
 
 variable "user_data_location" {
   type    = string
-  default = "template/ubuntu/20.04_focal/user-data"
+  default = "user-data"
 }
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/ubuntu/20.04_focal/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -442,7 +442,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/ubuntu/22.04_jammy/base-uefi.pkr.hcl
+++ b/source/ubuntu/22.04_jammy/base-uefi.pkr.hcl
@@ -241,12 +241,12 @@ variable "timezone" {
 
 variable "user_data_location" {
   type    = string
-  default = "template/ubuntu/22.04_jammy/user-data"
+  default = "user-data"
 }
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/ubuntu/22.04_jammy/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -459,7 +459,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/ubuntu/22.04_jammy/base.pkr.hcl
+++ b/source/ubuntu/22.04_jammy/base.pkr.hcl
@@ -241,12 +241,12 @@ variable "timezone" {
 
 variable "user_data_location" {
   type    = string
-  default = "template/ubuntu/22.04_jammy/user-data"
+  default = "user-data"
 }
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/ubuntu/22.04_jammy/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -442,7 +442,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/ubuntu/22.10_kinetic/base-uefi.pkr.hcl
+++ b/source/ubuntu/22.10_kinetic/base-uefi.pkr.hcl
@@ -241,12 +241,12 @@ variable "timezone" {
 
 variable "user_data_location" {
   type    = string
-  default = "template/ubuntu/22.10_kinetic/user-data"
+  default = "user-data"
 }
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/ubuntu/22.10_kinetic/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -459,7 +459,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {

--- a/source/ubuntu/22.10_kinetic/base.pkr.hcl
+++ b/source/ubuntu/22.10_kinetic/base.pkr.hcl
@@ -241,12 +241,12 @@ variable "timezone" {
 
 variable "user_data_location" {
   type    = string
-  default = "template/ubuntu/22.10_kinetic/user-data"
+  default = "user-data"
 }
 
 variable "vagrantfile_template" {
   type    = string
-  default = "template/ubuntu/22.10_kinetic/vagrant.rb.j2"
+  default = "vagrant.rb.j2"
 }
 
 variable "version" {
@@ -442,7 +442,7 @@ build {
     keep_input_artifact  = true
     only                 = ["qemu", "vbox"]
     output               = "${local.output_directory}/${var.vm_name}-${var.version}-${build.name}.box"
-    vagrantfile_template = var.vagrantfile_template
+    vagrantfile_template = "${path.root}/${var.vagrantfile_template}"
   }
 
   post-processor "compress" {


### PR DESCRIPTION
For this PR i'm not sure of my fix.
I am on Debian 11 with packer 1.8.1

The packer function `templatefile` will append the current `path.root` to the file so the build will fail :

> with var as object with 52 attributes,
>      var.preseed_file as "source/debian/11_bullseye/base.preseed".
> 
> Call to function "templatefile" failed: no file exists at
> source/debian/11_bullseye/source/debian/11_bullseye/base.preseed.

The solution for me was to get rid of the path and only use the filename.
To not have inconsistency in the configuration I also deleted the path from the vagrant template and I add `path.root `when needed
`"${path.root}/${var.vagrantfile_template}"`

It also fix the problem that the current path start with `template' instead of `source`

With this configuration I am able to cd to the root of the repo and successfully run :

> $  packer build source/debian/11_bullseye/base.pkr.hcl